### PR TITLE
only run asset timestamps on deploy

### DIFF
--- a/gulp/tasks/indices.js
+++ b/gulp/tasks/indices.js
@@ -1,6 +1,7 @@
 'use strict';
 import gulp         from 'gulp';
 import plugins      from 'gulp-load-plugins';
+import yargs        from 'yargs';
 import _            from 'lodash';
 import fs           from 'fs';
 import yaml         from 'js-yaml';
@@ -13,6 +14,9 @@ const $ = plugins();
 const { COMPATIBILITY, PORT, UNCSS_OPTIONS, PATHS } = loadConfig();
 
 const PAGE_SIZE = 12;
+
+// Check for --production flag
+const PRODUCTION = !!(yargs.argv.production);
 
 function loadConfig() {
   let ymlFile = fs.readFileSync('config.yml', 'utf8');
@@ -62,7 +66,7 @@ function buildingBlocksCategoryPages() {
       data: 'src/data/',
       helpers: 'src/panini-helpers/'
     }))
-    .pipe($.revTimestamp())
+    .pipe($.if(PRODUCTION, $.revTimestamp()))
     .pipe(gulp.dest(PATHS.dist));
   }
 

--- a/gulp/tasks/pages.js
+++ b/gulp/tasks/pages.js
@@ -1,6 +1,7 @@
 'use strict';
 import gulp         from 'gulp';
 import plugins      from 'gulp-load-plugins';
+import yargs        from 'yargs';
 import fs           from 'fs';
 import panini       from 'panini';
 import yaml         from 'js-yaml';
@@ -11,6 +12,10 @@ import path         from 'path';
 const $ = plugins();
 
 const { COMPATIBILITY, PORT, UNCSS_OPTIONS, PATHS } = loadConfig();
+
+// Check for --production flag
+const PRODUCTION = !!(yargs.argv.production);
+
 
 function loadConfig() {
   let ymlFile = fs.readFileSync('config.yml', 'utf8');
@@ -87,7 +92,7 @@ function buildingBlockIframe() {
     .pipe($.rename(function (path) {
       path.basename += "-iframe";
     }))
-    .pipe($.revTimestamp())
+    .pipe($.if(PRODUCTION, $.revTimestamp()))
     .pipe(gulp.dest(PATHS.dist + "/blocks/"));
   }
 
@@ -101,7 +106,7 @@ function buildingBlockPage() {
       data: ['src/data/', PATHS.build + '/data'],
       helpers: 'src/panini-helpers/'
     }))
-    .pipe($.revTimestamp())
+    .pipe($.if(PRODUCTION, $.revTimestamp()))
     .pipe(gulp.dest(PATHS.dist + "/blocks/"));
 }
 
@@ -120,7 +125,7 @@ function kitsPages() {
       data: ['src/data/', PATHS.build + '/data'],
       helpers: 'src/panini-helpers/'
     }))
-    .pipe($.revTimestamp())
+    .pipe($.if(PRODUCTION, $.revTimestamp()))
     .pipe(gulp.dest(PATHS.dist + "/kits/"));
 }
 

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -129,7 +129,7 @@ function kitIndex() {
       data: ['src/data/', PATHS.build + '/data'],
       helpers: 'src/panini-helpers/'
     }))
-    .pipe($.revTimestamp())
+    .pipe($.if(PRODUCTION, $.revTimestamp()))
     .pipe(gulp.dest(PATHS.dist));
   }
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "bb": "gulp bb",
     "bb-i": "gulp bb-iframe",
     "static": "gulp static",
-    "deploy": "gulp deploy"
+    "deploy": "gulp deploy --production"
   },
   "author": "ZURB <foundation@zurb.com>",
   "license": "MIT",


### PR DESCRIPTION
The revision timestamping turned out to be noisy and slow, so back it out to only run on deploy