### PR TITLE
fixed building block description issue

### DIFF
--- a/src/assets/scss/components/_preview-bb.scss
+++ b/src/assets/scss/components/_preview-bb.scss
@@ -33,13 +33,10 @@
 }
 
 .building-block-description {
-  background: $blue-gray-transparent;
-  bottom: 0;
+  background: $blue-gray;
   color: $medium-blue;
   font-weight: $global-weight-semibold;
   padding-top: rem-calc(15);
-  position: absolute;
   text-align: center;
   width: 100%;
-  z-index: 100;
 }

--- a/src/partials/building-block/building-block-preview.html
+++ b/src/partials/building-block/building-block-preview.html
@@ -2,9 +2,9 @@
   <div class="row align-center expanded building-block-iframe-wrapper">
     <iframe class="building-block-iframe" src="{{bb-iframe-path page}}" frameborder="0"></iframe>
   </div>
-  <div class="building-block-description">
-    <div class="row align-center">
-      <p>{{block.description}}</p>
-    </div>
+</div>
+<div class="building-block-description">
+  <div class="row align-center">
+    <p>{{block.description}}</p>
   </div>
 </div>


### PR DESCRIPTION
Building block descriptions were overlapping with bottom-fixed items in the iframe.