### PR TITLE
Make sticky footer more efficient

### DIFF
--- a/src/building-blocks/sticky-signup-bar/sticky-signup-bar.js
+++ b/src/building-blocks/sticky-signup-bar/sticky-signup-bar.js
@@ -1,12 +1,16 @@
+var $container = $('#subscription-container');
+var $window = $(window);
+var $footer = $('#email-subscription-footer');
+
 $(window).on("load scroll", function() {
-    var footerOffset = $('#subscription-container').offset().top;
-    var myScrollPosition = $(this).scrollTop();
-    var windowHeight = $(window).height();
-    var footerHeight = $('#email-subscription-footer').outerHeight();
+    var footerOffset = $container.offset().top;
+    var myScrollPosition = $window.scrollTop();
+    var windowHeight = $window.height();
+    var footerHeight = $footer.outerHeight();
 
     if ((myScrollPosition + windowHeight - footerHeight) > footerOffset) {
-      $('#email-subscription-footer').addClass('is-in-page');
+      $footer.addClass('is-in-page');
     } else {
-      $('#email-subscription-footer').removeClass('is-in-page');
+      $footer.removeClass('is-in-page');
     }
 });

--- a/src/building-blocks/sticky-signup-bar/sticky-signup-bar.js
+++ b/src/building-blocks/sticky-signup-bar/sticky-signup-bar.js
@@ -1,8 +1,8 @@
-var $container = $('#subscription-container');
-var $window = $(window);
-var $footer = $('#email-subscription-footer');
-
-$(window).on("load scroll", function() {
+(function() {
+  var $container = $('#subscription-container');
+  var $window = $(window);
+  var $footer = $('#email-subscription-footer');
+  $(window).on("load scroll", function() {
     var footerOffset = $container.offset().top;
     var myScrollPosition = $window.scrollTop();
     var windowHeight = $window.height();
@@ -13,4 +13,5 @@ $(window).on("load scroll", function() {
     } else {
       $footer.removeClass('is-in-page');
     }
-});
+  });
+})();


### PR DESCRIPTION
Noticed while using an instance of this building block that it was jittery - the reason is it was re-traversing the DOM to recapture items in ever scroll event.  This PR resolves this by "cashing them outside" (h/t @tdhartwick). 