### PR TITLE
Focusing on the search element after it is expanded

### DIFF
--- a/src/building-blocks/searchbar-expand-on-click/searchbar-expand-on-click.js
+++ b/src/building-blocks/searchbar-expand-on-click/searchbar-expand-on-click.js
@@ -4,5 +4,6 @@ $(function() {
   $('.search')
     .bind('click', function(event) {
       $(".search-field").toggleClass("expand-search");
+      $(".search-field").focus();
     })
 });


### PR DESCRIPTION
I've updated the [expandable searchbar](http://foundation.zurb.com/building-blocks/blocks/searchbar-expand-on-click.html) to focus on the search bar once it is expanded.

Thanks!