### PR TITLE
Only focus on search field when it is expanded

### DIFF
--- a/src/building-blocks/searchbar-expand-on-click/searchbar-expand-on-click.js
+++ b/src/building-blocks/searchbar-expand-on-click/searchbar-expand-on-click.js
@@ -4,6 +4,10 @@ $(function() {
   $('.search')
     .bind('click', function(event) {
       $(".search-field").toggleClass("expand-search");
-      $(".search-field").focus();
+
+      // if the search field is expanded, focus on it
+      if ($(".search-field").hasClass("expand-search")) {
+        $(".search-field").focus();
+      }
     })
 });


### PR DESCRIPTION
Minor improvement to the focus behaviour of the building block here: [http://foundation.zurb.com/building-blocks/blocks/searchbar-expand-on-click.html](http://foundation.zurb.com/building-blocks/blocks/searchbar-expand-on-click.html).