### PR TITLE
Fix minor issues with footer links

### DIFF
--- a/src/partials/footer.html
+++ b/src/partials/footer.html
@@ -24,16 +24,16 @@
   <div class="footer-nav-right">
     <ul class="footer-nav-menu-icons">
       <li class="footer-nav-menu-item">
-        <a href="{{root}}get-involved/support.html"><img class="footer-social-icon" src="{{root}}assets/img/icons/email-icon.svg" alt=""></a>
+        <a href="http://foundation.zurb.com/get-involved/support.html"><img class="footer-social-icon" src="{{root}}assets/img/icons/email-icon.svg" alt="Get Involved with Zurb Foundation"></a>
       </li>
       <li class="footer-nav-menu-item">
-        <a href="https://www.facebook.com/ZURB/"><img class="footer-social-icon" src="{{root}}assets/img/icons/facebook-icon.svg" alt=""></a>
+        <a href="https://www.facebook.com/ZURB/"><img class="footer-social-icon" src="{{root}}assets/img/icons/facebook-icon.svg" alt="ZURB Foundation Facebook"></a>
       </li>
       <li class="footer-nav-menu-item">
-        <a href="https://twitter.com/ZURBfoundation"><img class="footer-social-icon" src="{{root}}assets/img/icons/twitter-icon.svg" alt=""></a>
+        <a href="https://twitter.com/ZURBfoundation"><img class="footer-social-icon" src="{{root}}assets/img/icons/twitter-icon.svg" alt="ZURB Foundation Twitter"></a>
       </li>
       <li class="footer-nav-menu-item">
-        <a href="https://www.youtube.com/user/zurb"><img class="footer-social-icon" src="{{root}}assets/img/icons/youtube-icon.svg" alt=""></a>
+        <a href="https://www.youtube.com/user/zurb"><img class="footer-social-icon" src="{{root}}assets/img/icons/youtube-icon.svg" alt="ZURB Foundation Youtube"></a>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
- Support page link is currently broken
- Based on accessibility guidelines, the footer links which contain only images need to have an alt tag describing the link location. (https://www.w3.org/WAI/tutorials/images/decision-tree/)